### PR TITLE
Adding use_http_urls

### DIFF
--- a/models/root_action_descriptor.rb
+++ b/models/root_action_descriptor.rb
@@ -8,6 +8,7 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
 
   MERGE_REQUEST_PROCESSING = 'merge_request_processing'
   MERGED_BRANCH_PROCESSING = 'merged_branch_triggering'
+  USE_HTTP_URLS = 'use_http_urls'
   AUTOMATIC_PROJECT_CREATION_PROPERTY = 'automatic_project_creation'
   MASTER_BRANCH_PROPERTY = 'master_branch'
   USE_MASTER_PROJECT_NAME_PROPERTY = 'use_master_project_name'
@@ -30,6 +31,10 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
 
   def merged_branch_triggering?
     !!@merged_branch_triggering
+  end
+
+  def use_http_urls?
+    !!@use_http_urls
   end
 
   def automatic_project_creation?
@@ -56,6 +61,7 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
       @ignore_usernames             = read_property(doc, IGNORE_USERS, DEFAULT_IGNORE_USERS)
       @merge_request_processing     = read_property(doc, MERGE_REQUEST_PROCESSING, "true") == "true"
       @merged_branch_triggering     = read_property(doc, MERGED_BRANCH_PROCESSING, "false") == "true"
+      @use_http_urls                = read_property(doc, USE_HTTP_URLS, "false") == "true"
       @automatic_project_creation   = read_property(doc, AUTOMATIC_PROJECT_CREATION_PROPERTY) == "true"
       @use_master_project_name      = read_property(doc, USE_MASTER_PROJECT_NAME_PROPERTY) == "true"
       @master_branch                = read_property(doc, MASTER_BRANCH_PROPERTY)
@@ -79,6 +85,7 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
 
     write_property(doc, MERGE_REQUEST_PROCESSING, merge_request_processing?)
     write_property(doc, MERGED_BRANCH_PROCESSING, merged_branch_triggering?)
+    write_property(doc, USE_HTTP_URLS, use_http_urls?)
     write_property(doc, AUTOMATIC_PROJECT_CREATION_PROPERTY, automatic_project_creation?)
     write_property(doc, MASTER_BRANCH_PROPERTY, master_branch)
     write_property(doc, USE_MASTER_PROJECT_NAME_PROPERTY, use_master_project_name?)
@@ -136,6 +143,7 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
     @ignore_usernames         = form[IGNORE_USERS]
     @merge_request_processing = form[MERGE_REQUEST_PROCESSING] ? true : false
     @merged_branch_triggering = form[MERGED_BRANCH_PROCESSING] ? true : false
+    @use_http_urls            = form[USE_HTTP_URLS] ? true : false
     @automatic_project_creation = form[AUTOMATIC_PROJECT_CREATION_PROPERTY] ? true : false
     if automatic_project_creation?
       @master_branch              = form[AUTOMATIC_PROJECT_CREATION_PROPERTY][MASTER_BRANCH_PROPERTY]

--- a/models/values/merge_request_details.rb
+++ b/models/values/merge_request_details.rb
@@ -1,10 +1,12 @@
 require_relative 'abstract_details'
 require_relative '../exceptions/bad_request_exception'
+require_relative '../util/settings'
 
 require 'gitlab'
 
 module GitlabWebHook
   class MergeRequestDetails < AbstractDetails
+    include Settings
 
     def initialize(payload)
       raise(ArgumentError.new("request payload is required")) unless payload
@@ -52,7 +54,7 @@ module GitlabWebHook
     end
 
     def repository_url
-      payload["source"] ? payload["source"]["ssh_url"] : extended["ssh_url_to_repo"]
+      payload["source"] ? payload["source"][settings.use_http_urls ? "git_http_url" : "ssh_url"] : extended["ssh_url_to_repo"]
     end
 
     def repository_name

--- a/models/values/payload_request_details.rb
+++ b/models/values/payload_request_details.rb
@@ -1,7 +1,10 @@
 require_relative 'request_details'
+require_relative '../util/settings'
 
 module GitlabWebHook
   class PayloadRequestDetails < RequestDetails
+    include Settings
+      
     def initialize(payload)
       @payload = payload || raise(ArgumentError.new("request payload is required"))
       @kind = payload['object_kind'].nil? ? 'webhook' : payload['object_kind']
@@ -13,8 +16,8 @@ module GitlabWebHook
 
     def repository_url
       return "" unless payload["repository"]
-      return "" unless payload["repository"]["url"]
-      payload["repository"]["url"].strip
+      return "" unless payload["repository"][settings.use_http_urls ? "git_http_url" : "ssh_url"]
+      payload["repository"][settings.use_http_urls ? "git_http_url" : "ssh_url"].strip
     end
 
     def repository_group

--- a/spec/fixtures/descriptor.xml
+++ b/spec/fixtures/descriptor.xml
@@ -2,6 +2,7 @@
 <hudson.model.Descriptor plugin='gitlab-hook'>
   <merge_request_processing>true</merge_request_processing>
   <merged_branch_triggering>false</merged_branch_triggering>
+  <use_http_urls>false</use_http_urls>
   <automatic_project_creation>true</automatic_project_creation>
   <master_branch>primary</master_branch>
   <use_master_project_name>true</use_master_project_name>

--- a/spec/support/shared/settings.rb
+++ b/spec/support/shared/settings.rb
@@ -7,6 +7,7 @@ RSpec.shared_context 'settings' do
     allow(jenkins_instance).to receive(:descriptor) { settings }
     allow(settings).to receive(:merge_request_processing?) { true }
     allow(settings).to receive(:merged_branch_triggering?) { true }
+    allow(settings).to receive(:use_http_urls?) { true }
     allow(settings).to receive(:ignore_users) { "user 1, user 2, user 3" }
   end
 end

--- a/views/gitlab_web_hook_root_action/global.erb
+++ b/views/gitlab_web_hook_root_action/global.erb
@@ -14,6 +14,10 @@
       f.checkbox :checked => "#{descriptor.merged_branch_triggering?}"
     end
 
+    f.entry :title => "Use HTTP URLs instead of SSH URLs", :field => 'use_http_urls' do
+      f.checkbox :checked => "#{descriptor.use_http_urls?}"
+    end
+
     f.optionalBlock :title => "Automatic project creation", :name => 'automatic_project_creation', :checked => "#{descriptor.automatic_project_creation?}" do
       f.entry :title => 'Project master branch', :field => 'master_branch' do
         f.textbox :default => "#{descriptor.master_branch}"

--- a/views/gitlab_web_hook_root_action/help-use_http_urls.erb
+++ b/views/gitlab_web_hook_root_action/help-use_http_urls.erb
@@ -1,0 +1,2 @@
+Whether to use HTTP URLs instead of SSH URLs when creating the project. 
+If enabled it will specifically use the <code>git_http_url</code> payload attribute.

--- a/work/gitlab-hook-GitlabWebHookRootAction.xml
+++ b/work/gitlab-hook-GitlabWebHookRootAction.xml
@@ -2,6 +2,7 @@
 <hudson.model.Descriptor plugin='gitlab-hook'>
   <merge_request_processing>true</merge_request_processing>
   <merged_branch_triggering>true</merged_branch_triggering>
+  <use_http_urls>false</use_http_urls>
   <automatic_project_creation>true</automatic_project_creation>
   <master_branch>master</master_branch>
   <use_master_project_name>false</use_master_project_name>


### PR DESCRIPTION
There is a use case where one wants to use HTTP URLs instead of SSH base
URLs. This commit adds the use_http_urls setting and modify the
merge_request_details and payload_request_details in order to use the
new git_http_url field of the JSON payload